### PR TITLE
Stats - Better UI, Better Hovering, Better Comparison.

### DIFF
--- a/src/app/components/BudgetAssignmentChartRefactored.tsx
+++ b/src/app/components/BudgetAssignmentChartRefactored.tsx
@@ -255,7 +255,7 @@ export default function BudgetAssignmentChart({
   
   // Find the correct time unit for the current range
   const diffInDays = Math.abs((dateRange.end.getTime() - dateRange.start.getTime()) / (1000 * 60 * 60 * 24));
-  const xUnit = determineTimeUnit(diffInDays);
+  const xUnit = determineTimeUnit(diffInDays, true); // Force daily for line charts
 
   // Determine if we should show filtered title
   // hasActiveFilters already defined above

--- a/src/app/components/BudgetAssignmentChartRefactored.tsx
+++ b/src/app/components/BudgetAssignmentChartRefactored.tsx
@@ -103,7 +103,7 @@ export default function BudgetAssignmentChart({
     [selectedCategories.length, selectedGroups.length]
   );
   
-  const chartData = useChartData(transactions, categories, dateRange);
+  const chartData = useChartData(transactions, categories, dateRange, timeRange);
 
   // Get filtered categories for distance calculation - memoized with stable dependencies
   const filteredCategoriesWithGoals = useMemo(() => {

--- a/src/app/components/BudgetAssignmentChartRefactored.tsx
+++ b/src/app/components/BudgetAssignmentChartRefactored.tsx
@@ -58,6 +58,9 @@ ChartJS.register(
   comparisonSelectionPlugin
 );
 
+// Set Chart.js global font defaults
+ChartJS.defaults.font.family = 'Gabarito, system-ui, -apple-system, sans-serif';
+
 export default function BudgetAssignmentChart({
   assignments,
   categories,

--- a/src/app/components/BudgetAssignmentChartRefactored.tsx
+++ b/src/app/components/BudgetAssignmentChartRefactored.tsx
@@ -1,7 +1,7 @@
 // Refactored Budget Assignment Chart - Main Component
 'use client';
 
-import { useRef, useEffect, useMemo } from 'react';
+import { useRef, useEffect, useMemo, useCallback } from 'react';
 import { Bar, Line } from 'react-chartjs-2';
 import { format } from 'date-fns';
 import {
@@ -257,6 +257,14 @@ export default function BudgetAssignmentChart({
   // hasActiveFilters already defined above
 
   // Chart configurations with stable dependencies
+  // Real-time update callback for comparison data during dragging
+  const handleRealTimeUpdate = useCallback((newComparisonData: any) => {
+    // Only update if we're actively dragging to avoid unnecessary re-renders
+    if (isDragging) {
+      setComparisonData(newComparisonData);
+    }
+  }, [isDragging, setComparisonData]);
+
   const lineChartConfig = useLineChartConfig(
     chartData,
     categories,
@@ -269,7 +277,9 @@ export default function BudgetAssignmentChart({
     filteredCategoriesWithGoals,
     selectedCategories,
     xUnit,
-    comparisonData
+    comparisonData,
+    handleRealTimeUpdate,
+    calculateComparisonData
   );
 
   const volumeChartConfig = useVolumeChartConfig(

--- a/src/app/components/charts/ComparisonAnalysis.tsx
+++ b/src/app/components/charts/ComparisonAnalysis.tsx
@@ -250,7 +250,7 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
       )}
       
       {/* Show clear button only for custom drag selections, not for hover */}
-      {isCustomSelection && !isHovering && !isSinglePoint && (
+      {isCustomSelection && !isHovering && (
         <button
           onClick={onClearSelection}
           className="mt-3 text-xs text-white/50 hover:text-white/70 transition-colors"

--- a/src/app/components/charts/ComparisonAnalysis.tsx
+++ b/src/app/components/charts/ComparisonAnalysis.tsx
@@ -246,7 +246,7 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
           onClick={onClearSelection}
           className="mt-3 text-xs text-white/50 hover:text-white/70 transition-colors"
         >
-          Clear selection (show full period)
+          Clear selection
         </button>
       )}
       

--- a/src/app/components/charts/ComparisonAnalysis.tsx
+++ b/src/app/components/charts/ComparisonAnalysis.tsx
@@ -85,9 +85,12 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
                             : (!isNaN(categoryData.absoluteChange) && categoryData.absoluteChange >= 0 ? 'text-green' : 'text-orange-400')
                         }`}>
                           {isSinglePoint ? 
-                            // For single point, show the current value
-                            (shouldShowDistanceFromGoal && categoryData.startValue < 0 
-                              ? `${formatCurrency(Math.abs(categoryData.startValue))} over budget`
+                            // For single point, show the current value with clear labels
+                            (shouldShowDistanceFromGoal 
+                              ? (categoryData.startValue < 0 
+                                  ? `${formatCurrency(Math.abs(categoryData.startValue))} overspent`
+                                  : `${formatCurrency(categoryData.startValue)} remaining`
+                                )
                               : formatCurrency(categoryData.startValue)
                             )
                             :
@@ -134,9 +137,12 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
                     : (!isNaN(currentData.absoluteChange) && currentData.absoluteChange >= 0 ? 'text-green' : 'text-reddy')
                 }`}>
                   {isSinglePoint ?
-                    // For single point, show the current overall value
-                    (shouldShowDistanceFromGoal && currentData.startValue < 0 
-                      ? `${formatCurrency(Math.abs(currentData.startValue))} over budget`
+                    // For single point, show the current overall value with clear labels
+                    (shouldShowDistanceFromGoal 
+                      ? (currentData.startValue < 0 
+                          ? `${formatCurrency(Math.abs(currentData.startValue))} overspent`
+                          : `${formatCurrency(currentData.startValue)} remaining`
+                        )
                       : formatCurrency(currentData.startValue)
                     )
                     :
@@ -191,9 +197,12 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
                 : (!isNaN(currentData.absoluteChange) && currentData.absoluteChange >= 0 ? 'text-green' : 'text-reddy')
             }`}>
               {isSinglePoint ?
-                // For single point, show current value
-                (shouldShowDistanceFromGoal && currentData.startValue < 0 
-                  ? `${formatCurrency(Math.abs(currentData.startValue))} over budget`
+                // For single point, show current value with clear labels
+                (shouldShowDistanceFromGoal 
+                  ? (currentData.startValue < 0 
+                      ? `${formatCurrency(Math.abs(currentData.startValue))} overspent`
+                      : `${formatCurrency(currentData.startValue)} remaining`
+                    )
                   : formatCurrency(currentData.startValue)
                 )
                 :

--- a/src/app/components/charts/ComparisonAnalysis.tsx
+++ b/src/app/components/charts/ComparisonAnalysis.tsx
@@ -249,8 +249,8 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
         </div>
       )}
       
-      {/* Show clear button only for custom selections */}
-      {isCustomSelection && (
+      {/* Show clear button only for custom drag selections, not for hover */}
+      {isCustomSelection && !isHovering && !isSinglePoint && (
         <button
           onClick={onClearSelection}
           className="mt-3 text-xs text-white/50 hover:text-white/70 transition-colors"

--- a/src/app/components/charts/ComparisonAnalysis.tsx
+++ b/src/app/components/charts/ComparisonAnalysis.tsx
@@ -9,24 +9,29 @@ interface ComparisonAnalysisProps {
   defaultComparisonData: ComparisonData | null;
   shouldShowDistanceFromGoal: boolean;
   onClearSelection: () => void;
+  isHovering?: boolean; // Add prop to indicate if currently showing hover data
 }
 
 export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(({
   comparisonData,
   defaultComparisonData,
   shouldShowDistanceFromGoal,
-  onClearSelection
+  onClearSelection,
+  isHovering = false
 }) => {
   const currentData = comparisonData || defaultComparisonData;
   
   if (!currentData) return null;
 
   const isCustomSelection = comparisonData && comparisonData !== defaultComparisonData;
+  const isSinglePoint = currentData.timeSpan === 0; // Single point data has timeSpan of 0
 
   return (
     <div className="bg-white/[.05] rounded-lg p-4 border border-green/20">
       <h4 className="font-medium text-green mb-2">
-        {isCustomSelection ? 'Selected Range Analysis' : 'Full Period Analysis'}
+        {isHovering && isSinglePoint ? 'Hovered Point Analysis' : 
+         isSinglePoint ? 'Selected Point Analysis' : 
+         isCustomSelection ? 'Selected Range Analysis' : 'Full Period Analysis'}
         {shouldShowDistanceFromGoal && (
           <span className="text-xs text-white/60 ml-2 font-normal">
             (Distance from Goal)
@@ -39,13 +44,17 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
         <div className="space-y-3">
           {/* Period header */}
           <div className="text-sm text-white/70 border-b border-white/10 pb-2">
-            Comparison: {(() => {
+            {isSinglePoint ? 'Point: ' : 'Comparison: '}{(() => {
               try {
                 const start = new Date(currentData.startDate);
                 const end = new Date(currentData.endDate);
-                return `${format(start, 'MMM dd')} → ${format(end, 'MMM dd')}`;
+                if (isSinglePoint) {
+                  return format(start, 'MMM dd');
+                } else {
+                  return `${format(start, 'MMM dd')} → ${format(end, 'MMM dd')}`;
+                }
               } catch (error) {
-                return 'Invalid date range';
+                return isSinglePoint ? 'Invalid date' : 'Invalid date range';
               }
             })()}
             {shouldShowDistanceFromGoal && (
@@ -67,18 +76,36 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
                   <div className="text-right">
                     {hasData ? (
                       <>
-                        <span className={`font-medium ${!isNaN(categoryData.absoluteChange) && categoryData.absoluteChange >= 0 ? 'text-green' : 'text-orange-400'}`}>
-                          {!categoryData.absoluteChange || isNaN(categoryData.absoluteChange) || !isFinite(categoryData.absoluteChange)
-                            ? '£0.00'
-                            : `${categoryData.absoluteChange >= 0 ? '+' : ''}${formatCurrency(categoryData.absoluteChange)}`
+                        <span className={`font-medium ${
+                          isSinglePoint 
+                            ? (shouldShowDistanceFromGoal 
+                                ? (categoryData.startValue >= 0 ? 'text-green' : 'text-orange-400')
+                                : 'text-green'
+                              )
+                            : (!isNaN(categoryData.absoluteChange) && categoryData.absoluteChange >= 0 ? 'text-green' : 'text-orange-400')
+                        }`}>
+                          {isSinglePoint ? 
+                            // For single point, show the current value
+                            (shouldShowDistanceFromGoal && categoryData.startValue < 0 
+                              ? `${formatCurrency(Math.abs(categoryData.startValue))} over budget`
+                              : formatCurrency(categoryData.startValue)
+                            )
+                            :
+                            // For range, show the change
+                            (!categoryData.absoluteChange || isNaN(categoryData.absoluteChange) || !isFinite(categoryData.absoluteChange)
+                              ? '£0.00'
+                              : `${categoryData.absoluteChange >= 0 ? '+' : ''}${formatCurrency(categoryData.absoluteChange)}`
+                            )
                           }
                         </span>
-                        <span className={`ml-2 text-xs ${!isNaN(categoryData.percentageChange) && categoryData.percentageChange >= 0 ? 'text-green' : 'text-orange-400'}`}>
-                          {!categoryData.percentageChange || isNaN(categoryData.percentageChange) || !isFinite(categoryData.percentageChange)
-                            ? '(0.0%)'
-                            : `(${categoryData.percentageChange >= 0 ? '+' : ''}${categoryData.percentageChange.toFixed(1)}%)`
-                          }
-                        </span>
+                        {!isSinglePoint && (
+                          <span className={`ml-2 text-xs ${!isNaN(categoryData.percentageChange) && categoryData.percentageChange >= 0 ? 'text-green' : 'text-orange-400'}`}>
+                            {!categoryData.percentageChange || isNaN(categoryData.percentageChange) || !isFinite(categoryData.percentageChange)
+                              ? '(0.0%)'
+                              : `(${categoryData.percentageChange >= 0 ? '+' : ''}${categoryData.percentageChange.toFixed(1)}%)`
+                            }
+                          </span>
+                        )}
                       </>
                     ) : (
                       <span className="text-white/50 text-xs">
@@ -94,20 +121,40 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
           {/* Show overall change for context when we have category breakdown */}
           <div className="border-t border-white/10 pt-2 mt-3">
             <div className="flex justify-between items-center text-sm">
-              <span className="text-white/60">Overall Change:</span>
+              <span className="text-white/60">
+                {isSinglePoint ? 'Overall Value:' : 'Overall Change:'}
+              </span>
               <div className="text-right">
-                <span className={`font-medium ${!isNaN(currentData.absoluteChange) && currentData.absoluteChange >= 0 ? 'text-green' : 'text-reddy'}`}>
-                  {!currentData.absoluteChange || isNaN(currentData.absoluteChange) || !isFinite(currentData.absoluteChange)
-                    ? '£0.00'
-                    : `${currentData.absoluteChange >= 0 ? '+' : ''}${formatCurrency(currentData.absoluteChange)}`
+                <span className={`font-medium ${
+                  isSinglePoint 
+                    ? (shouldShowDistanceFromGoal 
+                        ? (currentData.startValue >= 0 ? 'text-green' : 'text-reddy')
+                        : 'text-green'
+                      )
+                    : (!isNaN(currentData.absoluteChange) && currentData.absoluteChange >= 0 ? 'text-green' : 'text-reddy')
+                }`}>
+                  {isSinglePoint ?
+                    // For single point, show the current overall value
+                    (shouldShowDistanceFromGoal && currentData.startValue < 0 
+                      ? `${formatCurrency(Math.abs(currentData.startValue))} over budget`
+                      : formatCurrency(currentData.startValue)
+                    )
+                    :
+                    // For range, show the change
+                    (!currentData.absoluteChange || isNaN(currentData.absoluteChange) || !isFinite(currentData.absoluteChange)
+                      ? '£0.00'
+                      : `${currentData.absoluteChange >= 0 ? '+' : ''}${formatCurrency(currentData.absoluteChange)}`
+                    )
                   }
                 </span>
-                <span className={`ml-2 text-xs ${!isNaN(currentData.percentageChange) && currentData.percentageChange >= 0 ? 'text-green' : 'text-reddy'}`}>
-                  {!currentData.percentageChange || isNaN(currentData.percentageChange) || !isFinite(currentData.percentageChange)
-                    ? '(0.0%)'
-                    : `(${currentData.percentageChange >= 0 ? '+' : ''}${currentData.percentageChange.toFixed(1)}%)`
-                  }
-                </span>
+                {!isSinglePoint && (
+                  <span className={`ml-2 text-xs ${!isNaN(currentData.percentageChange) && currentData.percentageChange >= 0 ? 'text-green' : 'text-reddy'}`}>
+                    {!currentData.percentageChange || isNaN(currentData.percentageChange) || !isFinite(currentData.percentageChange)
+                      ? '(0.0%)'
+                      : `(${currentData.percentageChange >= 0 ? '+' : ''}${currentData.percentageChange.toFixed(1)}%)`
+                    }
+                  </span>
+                )}
               </div>
             </div>
           </div>
@@ -118,34 +165,57 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
           <div>
             <span className="text-white/50">Time Span</span>
             <p className="font-medium">
-              {!currentData.timeSpan || isNaN(currentData.timeSpan) || !isFinite(currentData.timeSpan)
-                ? 'Unknown'
-                : currentData.timeSpan < 1 
-                  ? `${Math.round(currentData.timeSpan * 24)} hour${Math.round(currentData.timeSpan * 24) !== 1 ? 's' : ''}`
-                  : `${Math.round(currentData.timeSpan)} day${Math.round(currentData.timeSpan) !== 1 ? 's' : ''}`
+              {isSinglePoint ? 'Single Point' :
+                (!currentData.timeSpan || isNaN(currentData.timeSpan) || !isFinite(currentData.timeSpan)
+                  ? 'Unknown'
+                  : currentData.timeSpan < 1 
+                    ? `${Math.round(currentData.timeSpan * 24)} hour${Math.round(currentData.timeSpan * 24) !== 1 ? 's' : ''}`
+                    : `${Math.round(currentData.timeSpan)} day${Math.round(currentData.timeSpan) !== 1 ? 's' : ''}`
+                )
               }
             </p>
           </div>
           <div>
             <span className="text-white/50">
-              {shouldShowDistanceFromGoal ? 'Goal Progress' : 'Balance Change'}
+              {isSinglePoint 
+                ? (shouldShowDistanceFromGoal ? 'Current Status' : 'Current Balance')
+                : (shouldShowDistanceFromGoal ? 'Goal Progress' : 'Balance Change')
+              }
             </span>
-            <p className={`font-medium ${!isNaN(currentData.absoluteChange) && currentData.absoluteChange >= 0 ? 'text-green' : 'text-reddy'}`}>
-              {!currentData.absoluteChange || isNaN(currentData.absoluteChange) || !isFinite(currentData.absoluteChange)
-                ? '£0.00'
-                : `${currentData.absoluteChange >= 0 ? '+' : ''}${formatCurrency(currentData.absoluteChange)}`
+            <p className={`font-medium ${
+              isSinglePoint 
+                ? (shouldShowDistanceFromGoal 
+                    ? (currentData.startValue >= 0 ? 'text-green' : 'text-reddy')
+                    : 'text-green'
+                  )
+                : (!isNaN(currentData.absoluteChange) && currentData.absoluteChange >= 0 ? 'text-green' : 'text-reddy')
+            }`}>
+              {isSinglePoint ?
+                // For single point, show current value
+                (shouldShowDistanceFromGoal && currentData.startValue < 0 
+                  ? `${formatCurrency(Math.abs(currentData.startValue))} over budget`
+                  : formatCurrency(currentData.startValue)
+                )
+                :
+                // For range, show change
+                (!currentData.absoluteChange || isNaN(currentData.absoluteChange) || !isFinite(currentData.absoluteChange)
+                  ? '£0.00'
+                  : `${currentData.absoluteChange >= 0 ? '+' : ''}${formatCurrency(currentData.absoluteChange)}`
+                )
               }
             </p>
           </div>
-          <div>
-            <span className="text-white/50">Percentage Change</span>
-            <p className={`font-medium ${!isNaN(currentData.percentageChange) && currentData.percentageChange >= 0 ? 'text-green' : 'text-reddy'}`}>
-              {!currentData.percentageChange || isNaN(currentData.percentageChange) || !isFinite(currentData.percentageChange)
-                ? '0.0%'
-                : `${currentData.percentageChange >= 0 ? '+' : ''}${currentData.percentageChange.toFixed(1)}%`
-              }
-            </p>
-          </div>
+          {!isSinglePoint && (
+            <div>
+              <span className="text-white/50">Percentage Change</span>
+              <p className={`font-medium ${!isNaN(currentData.percentageChange) && currentData.percentageChange >= 0 ? 'text-green' : 'text-reddy'}`}>
+                {!currentData.percentageChange || isNaN(currentData.percentageChange) || !isFinite(currentData.percentageChange)
+                  ? '0.0%'
+                  : `${currentData.percentageChange >= 0 ? '+' : ''}${currentData.percentageChange.toFixed(1)}%`
+                }
+              </p>
+            </div>
+          )}
           <div>
             <span className="text-white/50">Period</span>
             <p className="font-medium text-xs">
@@ -156,7 +226,11 @@ export const ComparisonAnalysis: React.FC<ComparisonAnalysisProps> = React.memo(
                   if (isNaN(start.getTime()) || isNaN(end.getTime())) {
                     return 'Invalid dates';
                   }
-                  return `${format(start, 'MMM dd')} → ${format(end, 'MMM dd')}`;
+                  if (isSinglePoint) {
+                    return format(start, 'MMM dd, yyyy');
+                  } else {
+                    return `${format(start, 'MMM dd')} → ${format(end, 'MMM dd')}`;
+                  }
                 } catch (error) {
                   return 'Error formatting dates';
                 }

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -81,7 +81,22 @@ export const useLineChartConfig = (
             usePointStyle: true,
             pointStyle: "circle",
             color: '#ffffff',
-            padding: 20
+            padding: 20,
+            boxWidth: 12,
+            boxHeight: 12,
+            textAlign: 'left' as const,
+            generateLabels: function(chart: any) {
+              const labels = chart.data.datasets.map((dataset: any, index: number) => ({
+                text: `  ${dataset.label}`, // Spaces to push text further from point
+                fillStyle: dataset.borderColor,
+                strokeStyle: dataset.borderColor,
+                fontColor: '#ffffff',
+                lineWidth: 0,
+                pointStyle: 'circle',
+                datasetIndex: index
+              }));
+              return labels;
+            }
           },
           onClick: () => {}
         },

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -36,11 +36,11 @@ export const useLineChartConfig = (
           backgroundColor: 'rgba(186, 194, 255, 0.1)',
           fill: true,
           tension: 0.4,
-          pointRadius: chartData.dataPoints.length > 50 ? 2 : chartData.dataPoints.length > 30 ? 4 : 6,
-          pointHoverRadius: chartData.dataPoints.length > 50 ? 4 : chartData.dataPoints.length > 30 ? 6 : 10,
+          pointRadius: 3,
+          pointHoverRadius: 6,
           pointBackgroundColor: '#bac2ff',
           pointBorderColor: '#0a0a0a',
-          pointBorderWidth: 1,
+          pointBorderWidth: 0,
         }
       ]
     },

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -78,8 +78,12 @@ export const useLineChartConfig = (
         legend: {
           display: shouldShowDistanceFromGoal && filteredCategoriesWithGoals.length > 1,
           labels: {
-            color: '#ffffff'
-          }
+            usePointStyle: true,
+            pointStyle: "rectRounded",
+            color: '#ffffff',
+            padding: 20
+          },
+          onClick: () => {}
         },
         tooltip: {
           backgroundColor: 'rgba(0, 0, 0, 0.8)',
@@ -87,6 +91,8 @@ export const useLineChartConfig = (
           bodyColor: '#ffffff',
           borderColor: '#bac2ff',
           borderWidth: 1,
+          caretSize: 8,
+          caretPadding: 100,
           callbacks: {
             title: (context: TooltipItem<'line'>[]) => {
               const dateStr = context[0].label;

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -23,7 +23,9 @@ export const useLineChartConfig = (
   filteredCategoriesWithGoals: Category[],
   selectedCategories: string[],
   xUnit: 'day' | 'week' | 'month',
-  comparisonData: any // Add comparison data parameter
+  comparisonData: any, // Add comparison data parameter
+  onRealTimeUpdate?: (data: any) => void, // Add real-time update callback
+  calculateComparisonData?: (startIdx: number, endIdx: number, dataToUse: any[], datasets?: any[]) => any // Add calculation function
 ) => {
   return useMemo(() => ({
     type: 'line' as const,
@@ -61,7 +63,9 @@ export const useLineChartConfig = (
             selectedCategories,
             shouldShowDistanceFromGoal,
             distanceFromGoalData,
-            comparisonData
+            comparisonData,
+            onRealTimeUpdate,
+            calculateComparisonData
           }
         } as any, // Type assertion to avoid TypeScript issues
         title: {
@@ -309,7 +313,9 @@ export const useLineChartConfig = (
     distanceFromGoalData.datasets.length, 
     filteredCategoriesWithGoals.length,
     selectedCategories.length,
-    xUnit
+    xUnit,
+    onRealTimeUpdate,
+    calculateComparisonData
   ]);
 };
 

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -35,7 +35,7 @@ export const useLineChartConfig = (
           borderColor: '#bac2ff',
           backgroundColor: 'rgba(186, 194, 255, 0.1)',
           fill: true,
-          tension: 0.2,
+          tension: 0.4,
           pointRadius: chartData.dataPoints.length > 50 ? 2 : chartData.dataPoints.length > 30 ? 4 : 6,
           pointHoverRadius: chartData.dataPoints.length > 50 ? 4 : chartData.dataPoints.length > 30 ? 6 : 10,
           pointBackgroundColor: '#bac2ff',

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -65,7 +65,8 @@ export const useLineChartConfig = (
             distanceFromGoalData,
             comparisonData,
             onRealTimeUpdate,
-            calculateComparisonData
+            calculateComparisonData,
+            isDragging
           }
         } as any, // Type assertion to avoid TypeScript issues
         title: {

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -265,15 +265,8 @@ export const useVolumeChartConfig = (
                 const date = new Date(dateStr);
                 if (isNaN(date.getTime())) return dateStr;
                 
-                const diffInDays = Math.abs((dateRange.end.getTime() - dateRange.start.getTime()) / (1000 * 60 * 60 * 24));
-                
-                if (diffInDays <= 7) {
-                  return format(date, 'MMM dd, yyyy');
-                } else if (diffInDays <= 90) {
-                  return format(date, 'MMM dd, yyyy');
-                } else {
-                  return format(date, 'MMM yyyy');
-                }
+                // Always use daily formatting since we force daily granularity for line charts
+                return format(date, 'MMM dd, yyyy');
               } catch (error) {
                 console.error('Error formatting date in volume tooltip:', error, dateStr);
                 return dateStr;

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -41,6 +41,7 @@ export const useLineChartConfig = (
           backgroundColor: 'rgba(186, 194, 255, 0.1)',
           fill: true,
           tension: 0.4,
+          cubicInterpolationMode: 'monotone',
           pointRadius: 3,
           pointHoverRadius: 3,
           pointBackgroundColor: '#bac2ff',

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -72,7 +72,8 @@ export const useLineChartConfig = (
           color: '#ffffff',
           font: {
             size: 16,
-            weight: 'bold' as const
+            weight: 'bold' as const,
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
           }
         },
         legend: {
@@ -85,6 +86,9 @@ export const useLineChartConfig = (
             boxWidth: 12,
             boxHeight: 12,
             textAlign: 'left' as const,
+            font: {
+              family: 'Gabarito, system-ui, -apple-system, sans-serif'
+            },
             generateLabels: function(chart: any) {
               const labels = chart.data.datasets.map((dataset: any, index: number) => ({
                 text: `  ${dataset.label}`, // Spaces to push text further from point
@@ -108,6 +112,15 @@ export const useLineChartConfig = (
           borderWidth: 1,
           caretSize: 8,
           caretPadding: 100,
+          titleFont: {
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
+          },
+          bodyFont: {
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
+          },
+          footerFont: {
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
+          },
           callbacks: {
             title: (context: TooltipItem<'line'>[]) => {
               const dateStr = context[0].label;
@@ -260,6 +273,9 @@ export const useLineChartConfig = (
           ticks: {
             color: '#ffffff',
             maxTicksLimit: xUnit === 'day' ? 14 : xUnit === 'week' ? 8 : 12,
+            font: {
+              family: 'Gabarito, system-ui, -apple-system, sans-serif'
+            }
           }
         },
         y: {
@@ -268,6 +284,9 @@ export const useLineChartConfig = (
           },
           ticks: {
             color: '#ffffff',
+            font: {
+              family: 'Gabarito, system-ui, -apple-system, sans-serif'
+            },
             callback: function(value: any) {
               if (shouldShowDistanceFromGoal) {
                 const numValue = Number(value);
@@ -343,13 +362,17 @@ export const useVolumeChartConfig = (
           color: '#ffffff',
           font: {
             size: 14,
-            weight: 'bold' as const
+            weight: 'bold' as const,
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
           }
         },
         legend: {
           display: true,
           labels: {
-            color: '#ffffff'
+            color: '#ffffff',
+            font: {
+              family: 'Gabarito, system-ui, -apple-system, sans-serif'
+            }
           }
         },
         tooltip: {
@@ -358,6 +381,15 @@ export const useVolumeChartConfig = (
           bodyColor: '#ffffff',
           borderColor: '#bac2ff',
           borderWidth: 1,
+          titleFont: {
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
+          },
+          bodyFont: {
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
+          },
+          footerFont: {
+            family: 'Gabarito, system-ui, -apple-system, sans-serif'
+          },
           callbacks: {
             title: (context: TooltipItem<'bar'>[]) => {
               const dateStr = context[0].label;
@@ -429,6 +461,9 @@ export const useVolumeChartConfig = (
           ticks: {
             color: '#ffffff',
             maxTicksLimit: xUnit === 'day' ? 14 : xUnit === 'week' ? 8 : 12,
+            font: {
+              family: 'Gabarito, system-ui, -apple-system, sans-serif'
+            }
           },
           // @ts-ignore
           barPercentage: 1.0,
@@ -443,6 +478,9 @@ export const useVolumeChartConfig = (
           },
           ticks: {
             color: '#ffffff',
+            font: {
+              family: 'Gabarito, system-ui, -apple-system, sans-serif'
+            },
             callback: function(value: any) {
               return formatCurrency(Math.abs(Number(value)));
             }

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -79,7 +79,7 @@ export const useLineChartConfig = (
           display: shouldShowDistanceFromGoal && filteredCategoriesWithGoals.length > 1,
           labels: {
             usePointStyle: true,
-            pointStyle: "rectRounded",
+            pointStyle: "circle",
             color: '#ffffff',
             padding: 20
           },

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -42,9 +42,9 @@ export const useLineChartConfig = (
           fill: true,
           tension: 0.4,
           pointRadius: 3,
-          pointHoverRadius: 6,
+          pointHoverRadius: 3,
           pointBackgroundColor: '#bac2ff',
-          pointBorderColor: '#0a0a0a',
+          pointBorderColor: '#bac2ff',
           pointBorderWidth: 0,
         }
       ]

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -77,33 +77,22 @@ export const useLineChartConfig = (
           }
         },
         legend: {
-          display: shouldShowDistanceFromGoal && filteredCategoriesWithGoals.length > 1,
-          labels: {
-            usePointStyle: true,
-            pointStyle: "circle",
-            color: '#ffffff',
-            padding: 20,
-            boxWidth: 12,
-            boxHeight: 12,
-            textAlign: 'left' as const,
-            font: {
-              family: 'Gabarito, system-ui, -apple-system, sans-serif'
-            },
-            generateLabels: function(chart: any) {
-              const labels = chart.data.datasets.map((dataset: any, index: number) => ({
-                text: `  ${dataset.label}`, // Spaces to push text further from point
-                fillStyle: dataset.borderColor,
-                strokeStyle: dataset.borderColor,
-                fontColor: '#ffffff',
-                lineWidth: 0,
-                pointStyle: 'circle',
-                datasetIndex: index
-              }));
-              return labels;
-            }
-          },
-          onClick: () => {}
-        },
+  display: shouldShowDistanceFromGoal && filteredCategoriesWithGoals.length > 1,
+  labels: {
+    usePointStyle: true,
+    pointStyle: "circle",
+    color: '#ffffff',
+    padding: 20,
+    boxWidth: 10,
+    boxHeight: 8,
+    textAlign: 'left' as const,
+    font: {
+      family: 'Gabarito, system-ui, -apple-system, sans-serif',
+      size: 15 // Match your legend font size
+    }
+  },
+  onClick: () => {}
+},
         tooltip: {
           backgroundColor: 'rgba(0, 0, 0, 0.8)',
           titleColor: '#ffffff',

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -41,7 +41,7 @@ export const useLineChartConfig = (
           backgroundColor: 'rgba(186, 194, 255, 0.1)',
           fill: true,
           tension: 0.4,
-          cubicInterpolationMode: 'monotone',
+          cubicInterpolationMode: 'monotone' as const,
           pointRadius: 3,
           pointHoverRadius: 3,
           pointBackgroundColor: '#bac2ff',

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -119,7 +119,7 @@ export const useLineChartConfig = (
           },
           grid: {
             color: 'rgba(255, 255, 255, 0.1)',
-            alignToPixels: false,
+            alignToPixels: true,
             offset: false
           },
           ticks: {
@@ -127,8 +127,12 @@ export const useLineChartConfig = (
             maxTicksLimit: xUnit === 'day' ? 14 : xUnit === 'week' ? 8 : 12,
             font: {
               family: 'Gabarito, system-ui, -apple-system, sans-serif'
-            }
-          }
+            },
+            source: 'data' as const,
+            align: 'center' as const
+          },
+          bounds: 'data' as const,
+          offset: false
         },
         y: {
           grid: {
@@ -316,7 +320,7 @@ export const useVolumeChartConfig = (
           },
           grid: {
             color: 'rgba(255, 255, 255, 0.1)',
-            alignToPixels: false,
+            alignToPixels: true,
             offset: false
           },
           ticks: {
@@ -324,14 +328,16 @@ export const useVolumeChartConfig = (
             maxTicksLimit: xUnit === 'day' ? 14 : xUnit === 'week' ? 8 : 12,
             font: {
               family: 'Gabarito, system-ui, -apple-system, sans-serif'
-            }
+            },
+            source: 'data' as const,
+            align: 'center' as const
           },
+          bounds: 'data' as const,
+          offset: false,
           // @ts-ignore
           barPercentage: 1.0,
           // @ts-ignore
           categoryPercentage: 1.0,
-          // @ts-ignore
-          offset: false,
         },
         y: {
           grid: {

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -68,7 +68,7 @@ export const useLineChartConfig = (
           display: true,
           text: shouldShowDistanceFromGoal 
             ? `Category Progress Tracking (${filteredCategoriesWithGoals.length} categories)`
-            : `Account Balance Over Time (${chartData.dataPoints.length} points)`,
+            : `Account Balance Over Time`,
           color: '#ffffff',
           font: {
             size: 16,

--- a/src/app/components/charts/configs.ts
+++ b/src/app/components/charts/configs.ts
@@ -18,6 +18,7 @@ export const useLineChartConfig = (
   isDragging: boolean,
   dragStartDataIndex: number | null,
   dragEndDataIndex: number | null,
+  hoverDataIndex: number | null,
   shouldShowDistanceFromGoal: boolean,
   distanceFromGoalData: DistanceFromGoalData,
   filteredCategoriesWithGoals: Category[],
@@ -25,7 +26,9 @@ export const useLineChartConfig = (
   xUnit: 'day' | 'week' | 'month',
   comparisonData: any, // Add comparison data parameter
   onRealTimeUpdate?: (data: any) => void, // Add real-time update callback
-  calculateComparisonData?: (startIdx: number, endIdx: number, dataToUse: any[], datasets?: any[]) => any // Add calculation function
+  calculateComparisonData?: (startIdx: number, endIdx: number, dataToUse: any[], datasets?: any[]) => any, // Add calculation function
+  onHover?: (event: any, chart: any) => void, // Add hover handler
+  onHoverLeave?: (chart: any) => void // Add hover leave handler
 ) => {
   return useMemo(() => ({
     type: 'line' as const,
@@ -59,6 +62,7 @@ export const useLineChartConfig = (
           selectionState: {
             dragStartDataIndex,
             dragEndDataIndex,
+            hoverDataIndex,
             chartData,
             selectedCategories,
             shouldShowDistanceFromGoal,
@@ -99,153 +103,7 @@ export const useLineChartConfig = (
   onClick: () => {}
 },
         tooltip: {
-          backgroundColor: 'rgba(0, 0, 0, 0.8)',
-          titleColor: '#ffffff',
-          bodyColor: '#ffffff',
-          borderColor: '#bac2ff',
-          borderWidth: 1,
-          caretSize: 8,
-          caretPadding: 100,
-          titleFont: {
-            family: 'Gabarito, system-ui, -apple-system, sans-serif'
-          },
-          bodyFont: {
-            family: 'Gabarito, system-ui, -apple-system, sans-serif'
-          },
-          footerFont: {
-            family: 'Gabarito, system-ui, -apple-system, sans-serif'
-          },
-          callbacks: {
-            title: (context: TooltipItem<'line'>[]) => {
-              const dateStr = context[0].label;
-              let date: Date | null = null;
-              // Try ISO first
-              if (!isNaN(Date.parse(dateStr))) {
-                date = new Date(dateStr);
-              } else {
-                // Try parsing as "Apr 9, 2025, 12:00:00 p.m." (en-US)
-                // Remove the "p.m." or "a.m." and replace with AM/PM
-                const fixed = dateStr
-                  .replace('a.m.', 'AM')
-                  .replace('p.m.', 'PM')
-                  .replace('a.m', 'AM')
-                  .replace('p.m', 'PM');
-                date = new Date(fixed);
-              }
-              if (date && !isNaN(date.getTime())) {
-                // Determine if time should be shown by checking the interval between data points
-                const dataIndex = context[0].dataIndex;
-                const dataPoints = chartData.dataPoints;
-                let showTime = false;
-                if (dataPoints && dataPoints.length > 1 && dataIndex > 0) {
-                  const prevDate = new Date(dataPoints[dataIndex - 1].x);
-                  const currDate = new Date(dataPoints[dataIndex].x);
-                  const diffMs = Math.abs(currDate.getTime() - prevDate.getTime());
-                  // Less than 24 hours (86,400,000 ms)
-                  if (diffMs < 24 * 60 * 60 * 1000) {
-                    showTime = true;
-                  }
-                }
-                // Also show time if this is the first point and the next point is < 24h away
-                if (dataPoints && dataPoints.length > 1 && dataIndex === 0) {
-                  const nextDate = new Date(dataPoints[1].x);
-                  const currDate = new Date(dataPoints[0].x);
-                  const diffMs = Math.abs(nextDate.getTime() - currDate.getTime());
-                  if (diffMs < 24 * 60 * 60 * 1000) {
-                    showTime = true;
-                  }
-                }
-                if (showTime) {
-                  return format(date, 'MMM d, yyyy, h:mm a');
-                } else {
-                  return format(date, 'MMM d, yyyy');
-                }
-              }
-              // If still invalid, show as "Unrecognized date"
-              return 'Unrecognized date';
-            },
-            label: (context: TooltipItem<'line'>) => {
-              const value = context.parsed.y;
-              const datasetIndex = context.datasetIndex;
-              const category = filteredCategoriesWithGoals[datasetIndex];
-              
-              if (!category) {
-                return shouldShowDistanceFromGoal ? `${formatCurrency(value)} remaining` : `Balance: ${formatCurrency(value)}`;
-              }
-              
-              if (shouldShowDistanceFromGoal) {
-                if (category.goal === null || category.goal === undefined) {
-                  // Savings category
-                  if (value >= 0) {
-                    return `${category.name}: ${formatCurrency(value)} accumulated`;
-                  } else {
-                    return `${category.name}: ${formatCurrency(Math.abs(value))} spent from savings`;
-                  }
-                } else {
-                  // Regular spending category with goal
-                  if (value >= 0) {
-                    return `${category.name}: ${formatCurrency(value)} remaining`;
-                  } else {
-                    return `${category.name}: ${formatCurrency(Math.abs(value))} over budget`;
-                  }
-                }
-              } else {
-                return `Balance: ${formatCurrency(value)}`;
-              }
-            },
-            afterBody: (context: TooltipItem<'line'>[]) => {
-              if (shouldShowDistanceFromGoal) {
-                // Show additional goal information for distance from goal view
-                const datasetIndex = context[0].datasetIndex;
-                const category = filteredCategoriesWithGoals[datasetIndex];
-                if (category) {
-                  const currentValue = context[0].parsed.y;
-                  
-                  if (category.goal === null || category.goal === undefined) {
-                    // Savings category without goal
-                    const spentAmount = Math.max(0, -currentValue); // If negative, show how much was spent
-                    return [
-                      '',
-                      `Category Type: Savings/No Goal`,
-                      currentValue >= 0 
-                        ? `Value accumulated this month: ${formatCurrency(currentValue)}`
-                        : `Spent from savings this month: ${formatCurrency(spentAmount)}`
-                    ];
-                  } else {
-                    // Regular spending category with goal
-                    const goalAmount = category.goal;
-                    const spentAmount = goalAmount - currentValue;
-                    return [
-                      '',
-                      `Monthly Goal: ${formatCurrency(goalAmount)}`,
-                      `Month-to-date Spent: ${formatCurrency(Math.max(0, spentAmount))}`,
-                      currentValue >= 0 
-                        ? `Remaining this month: ${formatCurrency(currentValue)}`
-                        : `Over budget this month: ${formatCurrency(Math.abs(currentValue))}`
-                    ];
-                  }
-                }
-                return [];
-              } else {
-                // Show assignment breakdown for account balance view
-                const dataPoint = chartData.dataPoints[context[0].dataIndex];
-                if (dataPoint?.assignmentBreakdown) {
-                  const breakdown = Object.entries(dataPoint.assignmentBreakdown)
-                    .filter(([_, amount]) => Math.abs(amount as number) > 0)
-                    .sort(([,a], [,b]) => Math.abs(b as number) - Math.abs(a as number))
-                    .slice(0, 8)
-                    .map(([categoryId, amount]) => {
-                      const category = categories.find(c => c.id === categoryId);
-                      const amountNum = amount as number;
-                      const sign = amountNum >= 0 ? '+' : '-';
-                      return `${category?.name || 'Unknown'}: ${sign}${formatCurrency(Math.abs(amountNum))}`;
-                    });
-                  return breakdown.length > 0 ? ['', 'This Period:', ...breakdown] : [];
-                }
-                return [];
-              }
-            }
-          }
+          enabled: false // Disable tooltips in favor of hover lines and comparison analysis
         }
       },
       scales: {
@@ -296,9 +154,20 @@ export const useLineChartConfig = (
           }
         }
       },
-      onHover: (event: any, activeElements: any[]) => {
+      onHover: (event: any, activeElements: any[], chart: any) => {
         if (event.native && event.native.target) {
           (event.native.target as HTMLElement).style.cursor = isDragging ? 'grabbing' : 'crosshair';
+        }
+        
+        // Call custom hover handler if provided
+        if (onHover && event.native) {
+          onHover(event.native, chart);
+        }
+      },
+      onLeave: (event: any, activeElements: any[], chart: any) => {
+        // Call custom hover leave handler if provided
+        if (onHoverLeave) {
+          onHoverLeave(chart);
         }
       },
     }
@@ -309,14 +178,17 @@ export const useLineChartConfig = (
     dateRange.end.getTime(), 
     isDragging, 
     dragStartDataIndex, 
-    dragEndDataIndex, 
+    dragEndDataIndex,
+    hoverDataIndex,
     shouldShowDistanceFromGoal, 
     distanceFromGoalData.datasets.length, 
     filteredCategoriesWithGoals.length,
     selectedCategories.length,
     xUnit,
     onRealTimeUpdate,
-    calculateComparisonData
+    calculateComparisonData,
+    onHover,
+    onHoverLeave
   ]);
 };
 

--- a/src/app/components/charts/hooks/useChartData.ts
+++ b/src/app/components/charts/hooks/useChartData.ts
@@ -56,7 +56,8 @@ export const useFilteredTransactions = (
 export const useChartData = (
   transactions: Transaction[],
   categories: Category[],
-  dateRange: { start: Date; end: Date }
+  dateRange: { start: Date; end: Date },
+  timeRange?: '7d' | '30d' | '3m' | '12m' | 'all' | 'custom'
 ) => {
   return useMemo(() => {
     // Check if transactions is actually an array and validate inputs
@@ -128,10 +129,16 @@ export const useChartData = (
     if (clampedStart > dateRange.end) {
       return { dataPoints: [], volumePoints: [] };
     }
-    // --- Generate all period keys between clampedStart and end, even if no transactions ---
+    // If the selected range is 'All Time', force the end date to today
+    let effectiveEnd = dateRange.end;
+    if (timeRange === 'all') {
+      effectiveEnd = new Date();
+      effectiveEnd.setHours(12, 0, 0, 0);
+    }
+    // --- Generate all period keys between clampedStart and effectiveEnd, even if no transactions ---
     const allPeriodKeys: string[] = [];
     let current = new Date(clampedStart);
-    const end = new Date(dateRange.end);
+    const end = new Date(effectiveEnd);
     while (isBefore(current, end) || isEqual(current, end)) {
       allPeriodKeys.push(format(current, 'yyyy-MM-dd 12:00:00'));
       current = addDays(current, 1);
@@ -358,5 +365,5 @@ export const useChartData = (
     });
 
     return { dataPoints: alignedDataPoints, volumePoints: alignedVolumePoints };
-  }, [transactions, categories, dateRange]);
+  }, [transactions, categories, dateRange, timeRange]);
 };

--- a/src/app/components/charts/hooks/useChartData.ts
+++ b/src/app/components/charts/hooks/useChartData.ts
@@ -77,9 +77,9 @@ export const useChartData = (
       .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
     // Calculate the actual starting balance for the chart
-    // This should be: starting balance + all transactions before the date range
-    const startingTransaction = allTransactions.find(t => t && t.type === 'starting');
-    let chartStartingBalance = startingTransaction?.amount || 0;
+    // This should be: sum of all starting balances (one per account) + all transactions before the date range
+    const startingTransactions = allTransactions.filter(t => t && t.type === 'starting');
+    let chartStartingBalance = startingTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
     
     // Add all transactions that occurred before the date range to get the correct starting point
     const transactionsBeforeRange = allSorted.filter(transaction => {

--- a/src/app/components/charts/hooks/useChartData.ts
+++ b/src/app/components/charts/hooks/useChartData.ts
@@ -179,7 +179,7 @@ export const useChartData = (
           return acc;
         }
         
-        const key = getGranularityKey(transactionDate, diffInDays);
+        const key = getGranularityKey(transactionDate, diffInDays, true); // Force daily for line charts
         
         if (!acc[key]) {
           acc[key] = [];

--- a/src/app/components/charts/hooks/useComparisonAnalysis.ts
+++ b/src/app/components/charts/hooks/useComparisonAnalysis.ts
@@ -462,6 +462,17 @@ export const useComparisonAnalysis = (
     // Don't show hover if we're dragging
     if (isDragging) return;
     
+    // Don't show hover on touch devices to prevent unwanted hover activation
+    // Check if this is a touch device by looking for touch support
+    if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
+      return;
+    }
+    
+    // Also check if the event was triggered by a touch event
+    if ((event as any).sourceCapabilities && (event as any).sourceCapabilities.firesTouchEvents) {
+      return;
+    }
+    
     const clientX = getClientX(event);
     const dataIndex = getDataIndexFromPointerPosition(clientX, chart);
     

--- a/src/app/components/charts/hooks/useComparisonAnalysis.ts
+++ b/src/app/components/charts/hooks/useComparisonAnalysis.ts
@@ -9,6 +9,8 @@ export const useComparisonAnalysis = (
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartDataIndex, setDragStartDataIndex] = useState<number | null>(null);
   const [dragEndDataIndex, setDragEndDataIndex] = useState<number | null>(null);
+  const [hoverDataIndex, setHoverDataIndex] = useState<number | null>(null);
+  const [lastDragEndPosition, setLastDragEndPosition] = useState<{ x: number; dataIndex: number } | null>(null);
   const [comparisonData, setComparisonData] = useState<ComparisonData | null>(null);
   const [defaultComparisonData, setDefaultComparisonData] = useState<ComparisonData | null>(null);
 
@@ -236,6 +238,94 @@ export const useComparisonAnalysis = (
     }
   }, [selectedCategories, categoriesMap]);
 
+  // Helper function to calculate single-point data for hover
+  const calculateSinglePointData = useCallback((
+    dataIndex: number,
+    dataToUse: any[],
+    datasets?: any[]
+  ): ComparisonData | null => {
+    if (!dataToUse || dataToUse.length === 0) {
+      return null;
+    }
+    
+    const roundedIndex = Math.round(dataIndex);
+    
+    // Ensure index is within bounds
+    if (roundedIndex < 0 || roundedIndex >= dataToUse.length) {
+      return null;
+    }
+    
+    const point = dataToUse[roundedIndex];
+    if (!point) return null;
+    
+    const pointDate = point.x;
+    
+    try {
+      // For single point data, we show the current values rather than changes
+      let value: number;
+      let categoryBreakdown: Array<{
+        categoryId: string;
+        name: string;
+        startValue: number;
+        endValue: number;
+        absoluteChange: number;
+        percentageChange: number;
+      }> | undefined;
+      
+      // Handle category analysis when we have distance-from-goal datasets
+      if (datasets && datasets.length > 0) {
+        categoryBreakdown = [];
+        value = datasets[0].data[roundedIndex]?.y || 0;
+        
+        // Calculate breakdown for each category
+        datasets.forEach((dataset, index) => {
+          if (index < selectedCategories.length && categoryBreakdown) {
+            const categoryId = selectedCategories[index];
+            const category = categoriesMap.get(categoryId);
+            
+            if (category && dataset.data[roundedIndex]) {
+              const catValue = dataset.data[roundedIndex].y || 0;
+              
+              categoryBreakdown.push({
+                categoryId,
+                name: category.name,
+                startValue: catValue, // For single point, start and end are the same
+                endValue: catValue,
+                absoluteChange: 0, // No change for single point
+                percentageChange: 0 // No change for single point
+              });
+            }
+          }
+        });
+        
+        // For multiple categories, sum the values
+        if (selectedCategories.length > 1 && categoryBreakdown.length > 1) {
+          value = categoryBreakdown.reduce((sum, cat) => sum + cat.startValue, 0);
+        }
+      } else {
+        // Single account balance analysis
+        value = point.y || 0;
+      }
+      
+      // Validate value
+      if (isNaN(value) || !isFinite(value)) value = 0;
+      
+      return {
+        startDate: pointDate,
+        endDate: pointDate, // Same date for single point
+        startValue: value,
+        endValue: value,
+        absoluteChange: 0, // No change for single point
+        percentageChange: 0, // No change for single point
+        timeSpan: 0, // No time span for single point
+        categoryBreakdown
+      };
+    } catch (error) {
+      console.error('Error calculating single point data:', error);
+      return null;
+    }
+  }, [selectedCategories, categoriesMap]);
+
   // Helper function to convert pointer position to data index with smooth interpolation (no snapping)
   const getDataIndexFromPointerPosition = useCallback((clientX: number, chart: any): number | null => {
     const rect = chart.canvas.getBoundingClientRect();
@@ -283,6 +373,9 @@ export const useComparisonAnalysis = (
     const clientX = getClientX(event);
     const dataIndex = getDataIndexFromPointerPosition(clientX, chart);
     if (dataIndex !== null) {
+      // Clear hover state and previous drag position when starting a new drag selection
+      setHoverDataIndex(null);
+      setLastDragEndPosition(null);
       // Keep fractional index for smooth positioning - no rounding!
       setDragStartDataIndex(dataIndex);
       setDragEndDataIndex(dataIndex);
@@ -318,6 +411,9 @@ export const useComparisonAnalysis = (
       // Keep fractional index for smooth positioning - final selection can be fractional
       setDragEndDataIndex(dataIndex);
       setIsDragging(false);
+      
+      // Store the last drag end position for distance threshold checking
+      setLastDragEndPosition({ x: clientX, dataIndex });
     }
   }, [isDragging, dragStartDataIndex, getDataIndexFromPointerPosition, getClientX]);
 
@@ -357,13 +453,53 @@ export const useComparisonAnalysis = (
     setComparisonData(defaultComparisonData);
     setDragStartDataIndex(null);
     setDragEndDataIndex(null);
+    setHoverDataIndex(null);
+    setLastDragEndPosition(null);
   }, [defaultComparisonData]);
+
+  // Hover event handlers for single-point display
+  const handleHover = useCallback((event: MouseEvent, chart: any) => {
+    // Don't show hover if we're dragging
+    if (isDragging) return;
+    
+    const clientX = getClientX(event);
+    const dataIndex = getDataIndexFromPointerPosition(clientX, chart);
+    
+    // If we have a recent drag selection, check distance threshold before allowing hover
+    if (lastDragEndPosition && dragStartDataIndex !== null && dragEndDataIndex !== null) {
+      const DISTANCE_THRESHOLD = 50; // pixels
+      const DATA_INDEX_THRESHOLD = 2; // data points
+      
+      const pixelDistance = Math.abs(clientX - lastDragEndPosition.x);
+      const dataDistance = dataIndex !== null ? Math.abs(dataIndex - lastDragEndPosition.dataIndex) : 0;
+      
+      // Only allow hover if we're far enough away from the drag end position
+      if (pixelDistance < DISTANCE_THRESHOLD && dataDistance < DATA_INDEX_THRESHOLD) {
+        return; // Don't activate hover - too close to drag selection
+      }
+    }
+    
+    // Only update if the hover index changed significantly
+    const threshold = 0.1;
+    if (dataIndex !== null && (hoverDataIndex === null || Math.abs(hoverDataIndex - dataIndex) > threshold)) {
+      setHoverDataIndex(dataIndex);
+      chart.update('none');
+    }
+  }, [isDragging, hoverDataIndex, lastDragEndPosition, dragStartDataIndex, dragEndDataIndex, getDataIndexFromPointerPosition, getClientX]);
+
+  const handleHoverLeave = useCallback((chart: any) => {
+    if (hoverDataIndex !== null) {
+      setHoverDataIndex(null);
+      chart.update('none');
+    }
+  }, [hoverDataIndex]);
 
   return {
     // State
     isDragging,
     dragStartDataIndex,
     dragEndDataIndex,
+    hoverDataIndex,
     comparisonData,
     defaultComparisonData,
     
@@ -373,6 +509,11 @@ export const useComparisonAnalysis = (
     
     // Functions
     calculateComparisonData,
+    calculateSinglePointData,
+    
+    // Hover event handlers
+    handleHover,
+    handleHoverLeave,
     
     // Mouse event handlers (legacy)
     handleMouseDown,

--- a/src/app/components/charts/hooks/useComparisonAnalysis.ts
+++ b/src/app/components/charts/hooks/useComparisonAnalysis.ts
@@ -467,15 +467,21 @@ export const useComparisonAnalysis = (
     
     // If we have a recent drag selection, check distance threshold before allowing hover
     if (lastDragEndPosition && dragStartDataIndex !== null && dragEndDataIndex !== null) {
-      const DISTANCE_THRESHOLD = 50; // pixels
-      const DATA_INDEX_THRESHOLD = 2; // data points
+      const DISTANCE_THRESHOLD = 250;
+      const DATA_INDEX_THRESHOLD = 100;
       
       const pixelDistance = Math.abs(clientX - lastDragEndPosition.x);
       const dataDistance = dataIndex !== null ? Math.abs(dataIndex - lastDragEndPosition.dataIndex) : 0;
       
-      // Only allow hover if we're far enough away from the drag end position
-      if (pixelDistance < DISTANCE_THRESHOLD && dataDistance < DATA_INDEX_THRESHOLD) {
-        return; // Don't activate hover - too close to drag selection
+      // If we're far enough away, clear the drag selection and allow hover
+      if (pixelDistance >= DISTANCE_THRESHOLD || dataDistance >= DATA_INDEX_THRESHOLD) {
+        // User moved beyond threshold - clear the drag selection
+        setDragStartDataIndex(null);
+        setDragEndDataIndex(null);
+        setLastDragEndPosition(null);
+        setComparisonData(null); // This will reset to default comparison data
+      } else {
+        return; // Don't activate hover - still too close to drag selection
       }
     }
     

--- a/src/app/components/charts/hooks/useDistanceFromGoalData.ts
+++ b/src/app/components/charts/hooks/useDistanceFromGoalData.ts
@@ -124,9 +124,9 @@ export const useDistanceFromGoalData = (
         fill: false,
         tension: 0.4,
         pointRadius: 3,
-        pointHoverRadius: 6,
+        pointHoverRadius: 3,
         pointBackgroundColor: color,
-        pointBorderColor: '#0a0a0a',
+        pointBorderColor: `${color}`,
         pointBorderWidth: 0,
       };
     });

--- a/src/app/components/charts/hooks/useDistanceFromGoalData.ts
+++ b/src/app/components/charts/hooks/useDistanceFromGoalData.ts
@@ -123,6 +123,7 @@ export const useDistanceFromGoalData = (
         backgroundColor: `${color}20`,
         fill: false,
         tension: 0.4,
+        cubicInterpolationMode: 'monotone',
         pointRadius: 3,
         pointHoverRadius: 3,
         pointBackgroundColor: color,

--- a/src/app/components/charts/hooks/useDistanceFromGoalData.ts
+++ b/src/app/components/charts/hooks/useDistanceFromGoalData.ts
@@ -96,10 +96,18 @@ export const useDistanceFromGoalData = (
         };
       });
 
-      // Generate distinct colors for each category
+      // Colours for each category
       const colors = [
-        '#bac2ff', '#ff7f7f', '#7fff7f', '#ffff7f', '#ff7fff', 
-        '#7fffff', '#ffa500', '#ff69b4', '#98fb98', '#dda0dd'
+        '#BBC2FF',
+        '#84D684',
+        '#f2602f',
+        '#FFB3BA',
+        '#BAFFC9',
+        '#BAE1FF',
+        '#FFFFBA',
+        '#E6BAFF',
+        '#FFD1BA',
+        '#C9FFBA',
       ];
       const color = colors[index % colors.length];
 
@@ -115,11 +123,11 @@ export const useDistanceFromGoalData = (
         backgroundColor: `${color}20`,
         fill: false,
         tension: 0.2,
-        pointRadius: dataPoints.length > 50 ? 2 : dataPoints.length > 30 ? 4 : 6,
-        pointHoverRadius: dataPoints.length > 50 ? 4 : dataPoints.length > 30 ? 6 : 10,
+        pointRadius: 3,
+        pointHoverRadius: 6,
         pointBackgroundColor: color,
         pointBorderColor: '#0a0a0a',
-        pointBorderWidth: 1,
+        pointBorderWidth: 0,
       };
     });
 

--- a/src/app/components/charts/hooks/useDistanceFromGoalData.ts
+++ b/src/app/components/charts/hooks/useDistanceFromGoalData.ts
@@ -123,7 +123,7 @@ export const useDistanceFromGoalData = (
         backgroundColor: `${color}20`,
         fill: false,
         tension: 0.4,
-        cubicInterpolationMode: 'monotone',
+        cubicInterpolationMode: 'monotone' as const,
         pointRadius: 3,
         pointHoverRadius: 3,
         pointBackgroundColor: color,

--- a/src/app/components/charts/hooks/useDistanceFromGoalData.ts
+++ b/src/app/components/charts/hooks/useDistanceFromGoalData.ts
@@ -122,7 +122,7 @@ export const useDistanceFromGoalData = (
         borderColor: color,
         backgroundColor: `${color}20`,
         fill: false,
-        tension: 0.2,
+        tension: 0.4,
         pointRadius: 3,
         pointHoverRadius: 6,
         pointBackgroundColor: color,

--- a/src/app/components/charts/plugins.ts
+++ b/src/app/components/charts/plugins.ts
@@ -146,8 +146,9 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
       ctx.stroke();
       ctx.setLineDash([]);
       
-      // Draw shaded area only if not multiple categories
-      const shouldDrawShadedArea = selectedCategories.length <= 1;
+      // Draw shaded area - now works for both single and multiple categories
+      // Since we calculate overall change correctly, we can always show the visual feedback
+      const shouldDrawShadedArea = true;
       
       if (shouldDrawShadedArea) {      // Use the same logic as the ComparisonAnalysis component for color determination
       let isPositiveChange = false;

--- a/src/app/components/charts/plugins.ts
+++ b/src/app/components/charts/plugins.ts
@@ -115,18 +115,31 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
             const padding = 8;
             const labelY = bottom + 20;
             
+            // Adjust label position to keep it within chart bounds
+            let labelX = x;
+            const labelWidth = textWidth + padding * 2;
+            
+            // If label would extend past right edge, move it left
+            if (labelX + labelWidth/2 > right) {
+              labelX = right - labelWidth/2;
+            }
+            // If label would extend past left edge, move it right
+            if (labelX - labelWidth/2 < left) {
+              labelX = left + labelWidth/2;
+            }
+            
             // Draw background for date label
             ctx.fillStyle = 'rgba(186, 194, 255, 0.9)';
             ctx.beginPath();
-            ctx.moveTo(x + 4, labelY - textHeight/2 - padding/2);
-            ctx.lineTo(x + textWidth/2 + padding, labelY - textHeight/2 - padding/2);
-            ctx.quadraticCurveTo(x + textWidth/2 + padding, labelY - textHeight/2 - padding/2, x + textWidth/2 + padding, labelY - textHeight/2 - padding/2 + 4);
-            ctx.lineTo(x + textWidth/2 + padding, labelY + textHeight/2 + padding/2 - 4);
-            ctx.quadraticCurveTo(x + textWidth/2 + padding, labelY + textHeight/2 + padding/2, x + textWidth/2 + padding - 4, labelY + textHeight/2 + padding/2);
-            ctx.lineTo(x - textWidth/2 - padding + 4, labelY + textHeight/2 + padding/2);
-            ctx.quadraticCurveTo(x - textWidth/2 - padding, labelY + textHeight/2 + padding/2, x - textWidth/2 - padding, labelY + textHeight/2 + padding/2 - 4);
-            ctx.lineTo(x - textWidth/2 - padding, labelY - textHeight/2 - padding/2 + 4);
-            ctx.quadraticCurveTo(x - textWidth/2 - padding, labelY - textHeight/2 - padding/2, x - textWidth/2 - padding + 4, labelY - textHeight/2 - padding/2);
+            ctx.moveTo(labelX + 4, labelY - textHeight/2 - padding/2);
+            ctx.lineTo(labelX + textWidth/2 + padding, labelY - textHeight/2 - padding/2);
+            ctx.quadraticCurveTo(labelX + textWidth/2 + padding, labelY - textHeight/2 - padding/2, labelX + textWidth/2 + padding, labelY - textHeight/2 - padding/2 + 4);
+            ctx.lineTo(labelX + textWidth/2 + padding, labelY + textHeight/2 + padding/2 - 4);
+            ctx.quadraticCurveTo(labelX + textWidth/2 + padding, labelY + textHeight/2 + padding/2, labelX + textWidth/2 + padding - 4, labelY + textHeight/2 + padding/2);
+            ctx.lineTo(labelX - textWidth/2 - padding + 4, labelY + textHeight/2 + padding/2);
+            ctx.quadraticCurveTo(labelX - textWidth/2 - padding, labelY + textHeight/2 + padding/2, labelX - textWidth/2 - padding, labelY + textHeight/2 + padding/2 - 4);
+            ctx.lineTo(labelX - textWidth/2 - padding, labelY - textHeight/2 - padding/2 + 4);
+            ctx.quadraticCurveTo(labelX - textWidth/2 - padding, labelY - textHeight/2 - padding/2, labelX - textWidth/2 - padding + 4, labelY - textHeight/2 - padding/2);
             ctx.closePath();
             ctx.fill();
             
@@ -141,7 +154,7 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
             ctx.shadowBlur = 1;
             ctx.shadowOffsetX = 0;
             ctx.shadowOffsetY = 1;
-            ctx.fillText(dateLabel, x, labelY + 2);
+            ctx.fillText(dateLabel, labelX, labelY + 2);
             
             // Reset shadow
             ctx.shadowColor = 'transparent';

--- a/src/app/components/charts/plugins.ts
+++ b/src/app/components/charts/plugins.ts
@@ -225,5 +225,26 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
       
       ctx.restore();
     }
+    
+    // --- Draw horizontal zero line for clarity ---
+    if (scales.y) {
+      const yScale = scales.y;
+      // Only draw if zero is within the visible y range
+      if (yScale.min < 0 && yScale.max > 0) {
+        ctx.save();
+        ctx.beginPath();
+        ctx.moveTo(left, yScale.getPixelForValue(0));
+        ctx.lineTo(right, yScale.getPixelForValue(0));
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = 'rgba(255,255,255,0.7)';
+        ctx.setLineDash([8, 10]);
+        ctx.globalAlpha = 0.8;
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.globalAlpha = 1;
+        ctx.restore();
+      }
+    }
+    // --- End horizontal zero line ---
   }
 };

--- a/src/app/components/charts/plugins.ts
+++ b/src/app/components/charts/plugins.ts
@@ -151,7 +151,7 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
         const endLabel = format(rightDate, 'MMM dd');
         
         // Set up text styling
-        ctx.font = 'bold 12px Arial';
+        ctx.font = 'bold 12px Gabarito, system-ui, -apple-system, sans-serif';
         ctx.textAlign = 'center';
         
         // Calculate text dimensions for background

--- a/src/app/components/charts/plugins.ts
+++ b/src/app/components/charts/plugins.ts
@@ -371,6 +371,31 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
         // This creates a dedicated vertical space for selection labels
         const labelY = bottom + 20;
         
+        // Adjust label positions to keep them within chart bounds
+        let adjustedLeftX = leftX;
+        let adjustedRightX = rightX;
+        
+        const startLabelWidth = startTextWidth + padding * 2;
+        const endLabelWidth = endTextWidth + padding * 2;
+        
+        // If start label would extend past left edge, move it right
+        if (adjustedLeftX - startLabelWidth/2 < left) {
+          adjustedLeftX = left + startLabelWidth/2;
+        }
+        // If start label would extend past right edge, move it left
+        if (adjustedLeftX + startLabelWidth/2 > right) {
+          adjustedLeftX = right - startLabelWidth/2;
+        }
+        
+        // If end label would extend past right edge, move it left
+        if (adjustedRightX + endLabelWidth/2 > right) {
+          adjustedRightX = right - endLabelWidth/2;
+        }
+        // If end label would extend past left edge, move it right
+        if (adjustedRightX - endLabelWidth/2 < left) {
+          adjustedRightX = left + endLabelWidth/2;
+        }
+        
         // Draw background rectangles for labels with rounded corners
         ctx.fillStyle = 'rgba(186, 194, 255, 0.9)'; // Light blue background
         
@@ -390,12 +415,12 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
         };
         
         // Draw rounded background for start label
-        drawRoundedRect(leftX - startTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
+        drawRoundedRect(adjustedLeftX - startTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
                        startTextWidth + padding*2, textHeight + padding, 4);
         ctx.fill();
         
         // Draw rounded background for end label
-        drawRoundedRect(rightX - endTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
+        drawRoundedRect(adjustedRightX - endTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
                        endTextWidth + padding*2, textHeight + padding, 4);
         ctx.fill();
         
@@ -403,11 +428,11 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
         ctx.strokeStyle = '#bac2ff';
         ctx.lineWidth = 2;
         
-        drawRoundedRect(leftX - startTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
+        drawRoundedRect(adjustedLeftX - startTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
                        startTextWidth + padding*2, textHeight + padding, 4);
         ctx.stroke();
         
-        drawRoundedRect(rightX - endTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
+        drawRoundedRect(adjustedRightX - endTextWidth/2 - padding, labelY - textHeight/2 - padding/2, 
                        endTextWidth + padding*2, textHeight + padding, 4);
         ctx.stroke();
         
@@ -418,8 +443,8 @@ export const comparisonSelectionPlugin: Plugin<'line'> = {
         ctx.shadowOffsetX = 0;
         ctx.shadowOffsetY = 1;
         
-        ctx.fillText(startLabel, leftX, labelY + 2);
-        ctx.fillText(endLabel, rightX, labelY + 2);
+        ctx.fillText(startLabel, adjustedLeftX, labelY + 2);
+        ctx.fillText(endLabel, adjustedRightX, labelY + 2);
         
         // Reset shadow
         ctx.shadowColor = 'transparent';

--- a/src/app/components/charts/types.ts
+++ b/src/app/components/charts/types.ts
@@ -65,6 +65,7 @@ export interface DistanceFromGoalData {
     backgroundColor: string;
     fill: boolean;
     tension: number;
+    cubicInterpolationMode: 'monotone' | 'default';
     pointRadius: number;
     pointHoverRadius: number;
     pointBackgroundColor: string;

--- a/src/app/components/charts/utils.ts
+++ b/src/app/components/charts/utils.ts
@@ -61,7 +61,12 @@ export const calculateAllTimeRange = (assignments: Assignment[], transactions: T
   return { allTimeStart, allTimeEnd };
 };
 
-export const getGranularityKey = (date: Date, diffInDays: number) => {
+export const getGranularityKey = (date: Date, diffInDays: number, forceDaily: boolean = false) => {
+  // Force daily granularity for line charts - never aggregate by week or month
+  if (forceDaily) {
+    return format(date, 'yyyy-MM-dd 12:00:00');
+  }
+  
   // For up to 3 months, use daily
   if (diffInDays <= 90) {
     return format(date, 'yyyy-MM-dd 12:00:00');
@@ -84,7 +89,12 @@ export const getGranularityKey = (date: Date, diffInDays: number) => {
   }
 };
 
-export const determineTimeUnit = (diffInDays: number): 'day' | 'week' | 'month' => {
+export const determineTimeUnit = (diffInDays: number, forceDaily: boolean = false): 'day' | 'week' | 'month' => {
+  // Force daily unit for line charts - never use week or month
+  if (forceDaily) {
+    return 'day';
+  }
+  
   if (diffInDays <= 90) return 'day';
   else if (diffInDays <= 365) return 'week';
   else return 'month';


### PR DESCRIPTION
- No more tooltip
- Hovering over a date on desktop shows info for that date
- Updated colours - check these and see if you like - feel free to change (don't need to ask)
- Horizontal Zero Line
- Stats always end on the last date of the range, even if no transactions were for a while
- Other changes

STILL TODO:

- Income vs Spending Activity bar chart is not updated - debating whether to keep this. Might replace it with something like #134 
- Insights on selected time range - for example, if selected 30 days for 3 categories, show if spending is greater or less than some threshold from the previous 30 days - something like that (I plan to have a whole different insights page but I think it would look good to be here too)