### PR TITLE
Add timeRange prop to PieSegmentInsights and update comparison period…

### DIFF
--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -401,10 +401,11 @@ export default function Stats() {
                                                             onSetComparisonPeriod={handleSetComparisonPeriod}
                                                             isMobileOptimized={true}
                                                             isPersistedGroupView={!selectedPieSegment && !!persistedGroupSegment}
+                                                            timeRange={timeRange}
                                                         />
                                                     </div>
                                                     <div className="hidden lg:block" id="desktop-insights-panel">
-                                                        {/* Desktop insights - now also below the chart */}
+                                                        {/* Desktop insights */}
                                                         <PieSegmentInsights
                                                             segment={selectedPieSegment || persistedGroupSegment}
                                                             transactions={transactions}
@@ -415,6 +416,7 @@ export default function Stats() {
                                                             onSetComparisonPeriod={handleSetComparisonPeriod}
                                                             isMobileOptimized={false}
                                                             isPersistedGroupView={!selectedPieSegment && !!persistedGroupSegment}
+                                                            timeRange={timeRange}
                                                         />
                                                     </div>
                                                 </div>
@@ -423,7 +425,7 @@ export default function Stats() {
                                     );
                                 })()}
 
-                                {/* Budget Assignment Chart - NOW WITH TRANSACTIONS! */}
+                                {/* Budget Assignment Chart*/}
                                 <BudgetAssignmentChart
                                     assignments={assignments}
                                     categories={categories}


### PR DESCRIPTION


* Updated the comparison period calculation in `PieSegmentInsights.tsx` to handle MTD and YTD modes, so comparisons use the previous complete month or year instead of a simple duration-based approach. This makes insights more meaningful for these time ranges.



* Added a new optional `timeRange` prop to the `PieSegmentInsightsProps` interface and to the `PieSegmentInsights` component signature, allowing the component to determine the correct comparison logic based on the selected time range. [[1]](diffhunk://#diff-4415547b7958f4b423cc6f59649d38ddd061bc7c20f28f7be92f5d2e59554749R27) [[2]](diffhunk://#diff-4415547b7958f4b423cc6f59649d38ddd061bc7c20f28f7be92f5d2e59554749L38-R40)


* Passed the `timeRange` prop to both mobile and desktop instances of `PieSegmentInsights` in the stats page, ensuring consistent behavior across device layouts. [[1]](diffhunk://#diff-c27d3e3020fa5b43d68ff26c5187ecde3b17c4030c4c44293f4f0e287e0738ffR404-R408) [[2]](diffhunk://#diff-c27d3e3020fa5b43d68ff26c5187ecde3b17c4030c4c44293f4f0e287e0738ffR419)


* Cleaned up chart comments in the stats page for clarity.


* Added additional date functions (`subYears`, `startOfYear`, `endOfYear`) to support the new comparison logic.